### PR TITLE
Fix: resolve Zizmor template and env findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,11 +31,14 @@ runs:
     - name: 'Validate string/tag: CalVer'
       id: validate
       shell: bash
+      env:
+        INPUT_STRING: ${{ inputs.string }}
+        INPUT_EXIT_ON_FAIL: ${{ inputs.exit_on_fail }}
       # yamllint disable rule:line-length
       run: |
-        # Validate string/tag: CalVer
-        string="${{ inputs.string }}"
-        exit_on_fail="${{ inputs.exit_on_fail }}"
+        # Validate string/tag: CalVer
+        string="$INPUT_STRING"
+        exit_on_fail="$INPUT_EXIT_ON_FAIL"
 
         echo "String to check: $string"
         # Strip leading "v" character if present
@@ -49,23 +52,22 @@ runs:
           dev_version=true
         fi
         echo "Development/pre-release detected: $dev_version"
-        echo "dev_version=$dev_version" >> $GITHUB_ENV
-        echo "dev_version=$dev_version" >> $GITHUB_OUTPUT
+        echo "dev_version=$dev_version" >> "$GITHUB_OUTPUT"
 
         # See: https://regex101.com/r/BQfFYn/1
         # Best effort at a reasonable RegEx that accepts a number of variations
         pattern="^(\d{2}|\d{4}).(\d{1}|\d{2})(\.(\d{1}|\d{2})?((\.|\-|\_))[a-zA-Z0-9].*)$"
 
-        # Use grep with PCRE regular expression support
-        checked=$(echo $string | grep -P "$pattern" || true)
+        # Use grep with PCRE regular expression support. Feed the value
+        # via printf rather than echo so a string beginning with a dash
+        # (e.g. -n/-e) is not misread as an echo option.
+        checked=$(printf '%s' "$string" | grep -P "$pattern" || true)
         if [ "$checked" = "$string" ]; then
           echo "Tag/version string is valid CalVer ✅"
-          echo "valid=true" >> $GITHUB_ENV
-          echo "valid=true" >> $GITHUB_OUTPUT
+          echo "valid=true" >> "$GITHUB_OUTPUT"
         else
           echo "Tag/version string is NOT valid CalVer ❌"
-          echo "valid=false" >> $GITHUB_ENV
-          echo "valid=false" >> $GITHUB_OUTPUT
+          echo "valid=false" >> "$GITHUB_OUTPUT"
           if [ "f$exit_on_fail" = "ftrue" ]; then
             exit 1
           fi


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported `template-injection` and
`github-env` findings in this composite action. This change resolves
all of them, bringing the action to zero medium-or-higher findings.

### Changes

- **template-injection:** the validate step interpolated
  `${{ inputs.string }}` and `${{ inputs.exit_on_fail }}` directly into
  the bash `run` block. Both are now routed through a per-step `env:`
  block (`INPUT_STRING`, `INPUT_EXIT_ON_FAIL`) and referenced as quoted
  shell variables so nothing user-controlled is expanded into a run
  body. The value is fed to `grep` via `printf` rather than `echo` so a
  string beginning with a dash is not misread as an `echo` option.

- **github-env:** the step wrote `dev_version` and `valid` to both
  `$GITHUB_ENV` and `$GITHUB_OUTPUT`. The README documents only the step
  outputs as the public contract, so the redundant `$GITHUB_ENV` writes
  have been removed. This drops an undocumented side effect (those
  values leaking into the job environment for subsequent steps); the
  documented step-output contract is unchanged.

### Impact

No change to the action's documented step-output contract.
